### PR TITLE
Feature/slack object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 Integrate the outlook and slack API to allow users to schedule rooms with slash commands
+
+
+License
+=======
+
+The MIT License (MIT)
+
+Copyright (c) 2016 tapQA LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/lib/slack.response.object.js
+++ b/app/lib/slack.response.object.js
@@ -1,0 +1,53 @@
+'use strict';
+var _ = require('lodash');
+
+/**
+ * @constructor Slack Response
+ * @type SlackResponse
+ * @typedef SlackResponse object used when responding to slack API
+ * @param {Object} [data] - optional data to extend the default SlackResponse
+ * @returns {SlackResponse}
+ */
+function SlackResponse(data) {
+    _.extend(this, this.getResponseObject(data));
+}
+
+/**
+ * SlackResponse prototype
+ */
+SlackResponse.prototype = {
+    /**
+     * Build the response object
+     * @param {Object} data
+     * @returns {Object}
+     */
+    getResponseObject: function (data) {
+        data = data || {};
+        return _.merge(_.cloneDeep(this.DEFAULT_PROPERTIES), data);
+    },
+
+    /**
+     * Default response object properties
+     */
+    DEFAULT_PROPERTIES: {
+        response_type: 'ephemeral', // only let commanding user to see response
+    },
+
+    /**
+     * Extend the DEFAULT_PROPERTIES with new properties
+     * @param {Object|*} data - The object to extend, or the key for a new enumerable
+     * @param {*} [value] - optional value to pair with input key
+     * @returns
+     */
+    setDefaultProperties: function (data, value) {
+        if (data instanceof Object) {
+            _.merge(this.DEFAULT_PROPERTIES, data);
+        } else {
+            var tmp = {};
+            tmp[data] = value;
+            _.merge(this.DEFAULT_PROPERTIES, tmp);
+        }
+    }
+};
+
+module.exports = SlackResponse;

--- a/app/tests/lib/slack.response.object.test.js
+++ b/app/tests/lib/slack.response.object.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var _ = require('lodash'),
+    SlackResponse = require('../../lib/slack.response.object'),
+    testObject;
+
+describe('SlackResponse Object', function () {
+    beforeEach(function () {
+        testObject = new SlackResponse();
+    });
+
+    it('should be an object', function () {
+        testObject.should.be.instanceOf(Object);
+    });
+
+    it('should have default properties if no additional properties are provided', function () {
+        testObject.should.have.property('response_type').and.equal('ephemeral');
+    });
+
+    it('should extend the default properties if additional properties are provided', function () {
+        testObject = new SlackResponse({ yo: 'dawg' });
+        testObject.should.have.property('yo').and.equal('dawg');
+    });
+
+    describe('SlackResponse.protoype', function () {
+        it('should expose a getResponseObject function', function () {
+            SlackResponse.prototype.should.have.property('getResponseObject')
+                .and.is.instanceOf(Function);
+        });
+
+        it('should expose a DEFAULT_PROPERTIES object', function () {
+            SlackResponse.prototype.should.have.property('DEFAULT_PROPERTIES')
+                .and.is.instanceOf(Object);
+        });
+
+        it('should expose a setDefaultProperties function', function () {
+            SlackResponse.prototype.should.have.property('setDefaultProperties')
+                .and.is.instanceOf(Function);
+        });
+
+        describe('#getResponseObject()', function () {
+            it('should return an object', function () {
+                testObject.getResponseObject().should.be.instanceOf(Object);
+            });
+
+            it('should return default values if a data object isn\'t provided', function () {
+                (_.isEqual(testObject.getResponseObject(), testObject.DEFAULT_PROPERTIES))
+                    .should.be.true();
+            });
+
+            it('should extend the optional data object onto the response', function () {
+                testObject.getResponseObject({ foo: 'bar' })
+                    .should.have.property('foo')
+                    .and.equal('bar');
+            });
+
+            it('should not alter the DEFAULT_PROPERTIES objects', function () {
+                testObject.getResponseObject({ foo: 'bar' });
+                testObject.DEFAULT_PROPERTIES.should.not.have.property('foo');
+            });
+        });
+
+        describe('#setDefaultProperties()', function () {
+            it('should extend the provided object onto the DEFAULT_PROPERTIES', function () {
+                testObject.setDefaultProperties({ foo: 'bar' });
+                testObject.DEFAULT_PROPERTIES.should.have.property('foo')
+                    .and.equal('bar');
+            });
+
+            it('should extend the key/value pair onto the DEFAULT_PROPERTIES', function () {
+                testObject.setDefaultProperties('test', 'value');
+                testObject.DEFAULT_PROPERTIES.should.have.property('test')
+                    .and.equal('value');
+            });
+        });
+    });
+});


### PR DESCRIPTION
- Create SlackResponse object to be used to respond to the slack API
- Put license in the bottom of the readme
